### PR TITLE
[feature] Allow for supplying property types and default value configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ app.get('/', function (req, res) {
 When requests to this `express` application come in `morgan` will output a JSON object that looks
 like:
 
-```
-{"short":"GET / 200","length":200,"response-time":"2 ms"}
+``` json
+{"short":"GET / 200","length":"200","response-time":"2 ms"}
 ```
 
 ### Format objects
@@ -58,8 +58,8 @@ app.use(morgan(format));
 
 Will output a JSON object that has keys `short`, `length` and `response-time`:
 
-```
-{"short":"GET / 200","length":200,"response-time":"2 ms"}
+``` json
+{"short":"GET / 200","length":"200","response-time":"2 ms"}
 ```
 
 ### Format strings
@@ -79,7 +79,7 @@ app.use(morgan(format));
 
 Will output a JSON object that has keys `method`, `url`, `status`, `res` and `response-time`:
 
-```
+``` json
 {"method":"GET","url":"/","status":"200","res":"10 bytes","response-time":"2 ms"}
 ```
 
@@ -88,7 +88,6 @@ Will output a JSON object that has keys `method`, `url`, `status`, `res` and `re
 By default functions returned by `morgan-json` will return strings from `JSON.stringify`. In some
 cases you may want object literals (e.g. if you perform stringification in another layer of your logger). In this case just provide `{ stringify: false }`:
 
-``` js
 ``` js
 const morgan = require('morgan');
 const winston = require('winston');
@@ -105,12 +104,180 @@ app.use(morgan(format, {
 }));
 ```
 
-Will output a JSON object that has keys
+Will output a JSON object that has keys:
+
+``` json
+{"method":"GET","url":"/","status":"200"}
+```
+
+### Token options
+
+When using [Format objects](#format-objects), you can also specify options for each property by provide an object rather than a string
+
+``` js
+const morgan = require('morgan');
+const json = require('morgan-json');
+
+const format = json({
+  method: {
+    value: ':method'
+  },
+  'req-length': {
+    value: ':req[content-length]'
+  },
+  'response-time': {
+    value: ':response-time ms'
+  }
+});
+
+app.use(morgan(format));
+```
+
+Will output a JSON object that has keys `method`, `req-length` and `response-time`:
+
+``` json
+{"method":"GET","req-length":"16536","response-time":"2 ms"}
+```
+
+#### `type` option
+
+By default `morgan-json` assumes that all property values in the resulting json object should be strings. You can allow for the original value to pass-through by specifying a `type` token option. If no `type` token option is specified, it is assumed to be `string`.
+
+``` js
+const morgan = require('morgan');
+const json = require('morgan-json');
+
+const format = json({
+  method: {
+    value: ':method',
+    type: 'string'
+  },
+  'req-length': {
+    value: ':req[content-length]',
+    type: '*'
+  },
+  'response-time': {
+    value: ':response-time',
+    type: '*'
+  }
+});
+
+app.use(morgan(format));
+```
+
+Will output a JSON object that has keys `method`, `req-length` and `response-time` (note that `req-length` is still a string since it's reading a header value that is usually typed as a string):
+
+``` json
+{"method":"GET","req-length":"16536","response-time":2}
+```
+
+##### `type` converter options
+
+You can also specify a type converter to be used to output the value for a token. This can be useful when reading values that may be typed as a string.
+
+``` js
+const morgan = require('morgan');
+const json = require('morgan-json');
+
+const format = json({
+  method: {
+    value: ':method',
+    type: 'string'
+  },
+  'req-length': {
+    value: ':req[content-length]',
+    type: function(value, tokenName, tokenArg) {
+      // `tokenName` will be 'req'
+      // `tokenArg` will be 'content-length'
+      if (typeof value === 'string') {
+        return parseInt(value, 10);
+      }
+      return value;
+    }
+  },
+  'response-time': {
+    value: ':response-time',
+    type: '*'
+  }
+});
+
+app.use(morgan(format));
+```
+
+Will output a JSON object that has keys `method`, `req-length`:
+
+``` json
+{"method":"GET","req-length":16536}
+```
+
+#### `defaultValue` option
+
+By default `morgan-json` defaults tokens to `"-"` if there is a falsy value. You can use the `defaultValue` token option to change that.
+
+``` js
+const morgan = require('morgan');
+const json = require('morgan-json');
+
+const format = json({
+  method: {
+    value: ':method'
+  },
+  'req-length': {
+    value: ':req[content-length]'
+  },
+  'req-length-default': {
+    value: ':req[content-length]',
+    defaultValue: '0'
+  }
+});
+
+app.use(morgan(format));
+```
+
+Assuming there was no `content-length` header on the request, this will output a JSON object that has keys `method`, `req-length` and `req-length-default`:
+
+``` json
+{"method":"GET","req-length":"-","req-length-default":"0"}
+```
+
+#### `noDefault` option
+
+If you do not want a default value, you can use the `noDefault` token option to specify that. However, if the resulting type should be a string, the token will be an empty string rather than `null` or `undefined`.
+
+``` js
+const morgan = require('morgan');
+const json = require('morgan-json');
+
+const format = json({
+  method: {
+    value: ':method'
+  },
+  'req-length': {
+    value: ':req[content-length]'
+  },
+  'req-length-no-default': {
+    value: ':req[content-length]',
+    noDefault: true
+  },
+  'req-length-number': {
+    value: ':req[content-length]',
+    type: '*',
+    noDefault: true
+  }
+});
+
+app.use(morgan(format));
+```
+
+Assuming there was no `content-length` header on the request, this will output a JSON object that has keys `method`, `req-length` and `req-length-default`:
+
+``` json
+{"method":"GET","req-length":"-","req-length-no-default":"","req-length-number":null}
 ```
 
 ## Tests
 
-```
+``` sh
 npm test
 ```
 

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ app.use(morgan(format));
 Will output a JSON object that has keys `method`, `req-length`:
 
 ``` json
-{"method":"GET","req-length":16536}
+{"method":"GET","req-length":16536,"response-time":2}
 ```
 
 #### `defaultValue` option

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ When requests to this `express` application come in `morgan` will output a JSON 
 like:
 
 ``` json
-{"short":"GET / 200","length":"200","response-time":"2 ms"}
+{"short":"GET / 200","length":"200","response-time":"2.1 ms"}
 ```
 
 ### Format objects
@@ -59,7 +59,7 @@ app.use(morgan(format));
 Will output a JSON object that has keys `short`, `length` and `response-time`:
 
 ``` json
-{"short":"GET / 200","length":"200","response-time":"2 ms"}
+{"short":"GET / 200","length":"200","response-time":"2.1 ms"}
 ```
 
 ### Format strings
@@ -80,7 +80,7 @@ app.use(morgan(format));
 Will output a JSON object that has keys `method`, `url`, `status`, `res` and `response-time`:
 
 ``` json
-{"method":"GET","url":"/","status":"200","res":"10 bytes","response-time":"2 ms"}
+{"method":"GET","url":"/","status":"200","res":"10 bytes","response-time":"2.1 ms"}
 ```
 
 ### Returning strings vs. Objects
@@ -136,7 +136,7 @@ app.use(morgan(format));
 Will output a JSON object that has keys `method`, `req-length` and `response-time`:
 
 ``` json
-{"method":"GET","req-length":"16536","response-time":"2 ms"}
+{"method":"GET","req-length":"16536","response-time":"2.1 ms"}
 ```
 
 #### `type` option
@@ -168,7 +168,7 @@ app.use(morgan(format));
 Will output a JSON object that has keys `method`, `req-length` and `response-time` (note that `req-length` is still a string since it's reading a header value that is usually typed as a string):
 
 ``` json
-{"method":"GET","req-length":"16536","response-time":2}
+{"method":"GET","req-length":"16536","response-time":2.1}
 ```
 
 ##### `type` converter options
@@ -204,10 +204,42 @@ const format = json({
 app.use(morgan(format));
 ```
 
-Will output a JSON object that has keys `method`, `req-length`:
+Will output a JSON object that has keys `method`, `req-length`, `response-time`:
 
 ``` json
-{"method":"GET","req-length":16536,"response-time":2}
+{"method":"GET","req-length":16536,"response-time":2.1}
+```
+
+##### Built-in `type` converters
+
+There are a few type converters provided for common use cases:
+
+``` js
+const morgan = require('morgan');
+const json = require('morgan-json');
+const converters = require('morgan-json/converters');
+
+const format = json({
+  method: {
+    value: ':method',
+    type: 'string'
+  },
+  'req-length': {
+    value: ':req[content-length]',
+    type: converters.integer,
+  'response-time': {
+    value: ':response-time',
+    type: converters.float
+  }
+});
+
+app.use(morgan(format));
+```
+
+Will output a JSON object that has keys `method`, `req-length`, `response-time`:
+
+``` json
+{"method":"GET","req-length":16536,"response-time":2.1}
 ```
 
 #### `defaultValue` option

--- a/converters.js
+++ b/converters.js
@@ -1,0 +1,33 @@
+
+function integer(value) {
+  const type = typeof value;
+
+  if (type === 'string') {
+    return parseInt(value, 10);
+  }
+
+  if (type !== 'number') {
+    return null;
+  }
+  
+  return value;
+}
+
+function float(value) {
+  const type = typeof value;
+
+  if (type === 'string') {
+    return parseFloat(value);
+  }
+
+  if (type !== 'number') {
+    return null;
+  }
+  
+  return value;
+}
+
+module.exports = {
+  integer,
+  float
+}

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ module.exports = function compile (format, opts) {
  *
  * Adopted from `morgan.compile` from `morgan` under MIT.
  *
- * @param {string|Object} format
+ * @param {Object} format
  * @param {Object} opts Options for how things are returned.
  *   - 'stringify': (default: true) If false returns an object literal
  * @return {function}
@@ -67,17 +67,24 @@ function compileObject (format, opts) {
 
   var keys = Object.keys(format);
   var stringify = opts.stringify !== false ? 'JSON.stringify' : '';
+  var conversionFunctions = Object.create(null);
   var js = '  "use strict"\n  return ' + stringify + '({' + keys.map(function (key, i) {
-    var assignment = '\n    "' + key + '": "' + format[key].replace(/:([-\w]{2,})(?:\[([^\]]+)\])?/g, function (_, name, arg) {
-      var tokenArguments = 'req, res';
-      var tokenFunction = 'tokens[' + String(JSON.stringify(name)) + ']';
+    var token = Object.assign(
+      { type: 'string', defaultValue: '-', required: true },
+      (typeof format[key] === 'object') ? format[key] : {
+        value: format[key]
+      });
 
-      if (arg !== undefined) {
-        tokenArguments += ', ' + String(JSON.stringify(arg));
-      }
+    var getValue = getValueByType[token.type];
+    if (typeof token.type === 'function') {
+      getValue = getTypeConvertedValue;
+      conversionFunctions[key] = token.type;
+    }
+    if (!getValue) {
+      throw new Error('invalid "type" specified for property: ' + key);
+    }
 
-      return '" + (' + tokenFunction + '(' + tokenArguments + ') || "-") + "';
-    }) + '"';
+    var assignment = '\n    "' + key + '": ' + getValue(token, key);
 
     return assignment;
   }) + '\n  })';
@@ -85,5 +92,66 @@ function compileObject (format, opts) {
   debug('\n%s', js);
 
   // eslint-disable-next-line no-new-func
-  return new Function('tokens, req, res', js);
+  return new Function('convert, tokens, req, res', js).bind(null, conversionFunctions);
 };
+
+var getValueByType = {
+  'string': getStringValue,
+  '*': getPassthroughValue
+};
+
+function getStringValue(token) {
+  var assignment = '"' + token.value.replace(/:([-\w]{2,})(?:\[([^\]]+)\])?/g, function (_, name, arg) {
+    var tokenArguments = 'req, res';
+    var tokenFunction = 'tokens[' + String(JSON.stringify(name)) + ']';
+
+    if (arg !== undefined) {
+      tokenArguments += ', ' + String(JSON.stringify(arg));
+    }
+
+    var defaultValue = token.noDefault ? 
+      ' || ""' : 
+      ' || ' + JSON.stringify(token.defaultValue);
+
+    return '" + (' + tokenFunction + '(' + tokenArguments + ')' + defaultValue + ') + "';
+  }) + '"';
+
+  return assignment;
+}
+
+function getPassthroughValue(token) {
+  var assignment = token.value.replace(/:([-\w]{2,})(?:\[([^\]]+)\])?/g, function (_, name, arg) {
+    var tokenArguments = 'req, res';
+    var tokenFunction = 'tokens[' + String(JSON.stringify(name)) + ']';
+
+    if (arg !== undefined) {
+      tokenArguments += ', ' + String(JSON.stringify(arg));
+    }
+
+    var defaultValue = token.noDefault ? 
+      '' : 
+      ' || ' + JSON.stringify(token.defaultValue);
+    return '(' + tokenFunction + '(' + tokenArguments + ')' + defaultValue + ')';
+  });
+
+  return assignment;
+}
+
+function getTypeConvertedValue(token, key) {
+  var assignment = token.value.replace(/:([-\w]{2,})(?:\[([^\]]+)\])?/g, function (_, name, arg) {
+    var tokenArguments = 'req, res';
+    var tokenFunction = 'tokens[' + String(JSON.stringify(name)) + ']';
+
+    if (arg !== undefined) {
+      tokenArguments += ', ' + String(JSON.stringify(arg));
+    }
+
+    var defaultValue = token.noDefault ? 
+      '' : 
+      ' || ' + JSON.stringify(token.defaultValue);
+    return '(convert["' + key + '"](' + tokenFunction + '(' + tokenArguments + '))' + defaultValue + ')';
+  });
+
+  return assignment;
+}
+

--- a/index.js
+++ b/index.js
@@ -140,16 +140,20 @@ function getPassthroughValue(token) {
 function getTypeConvertedValue(token, key) {
   var assignment = token.value.replace(/:([-\w]{2,})(?:\[([^\]]+)\])?/g, function (_, name, arg) {
     var tokenArguments = 'req, res';
-    var tokenFunction = 'tokens[' + String(JSON.stringify(name)) + ']';
+    var name = String(JSON.stringify(name));
+    var tokenFunction = 'tokens[' + name + ']';
+    var convertArgs = name;
 
     if (arg !== undefined) {
-      tokenArguments += ', ' + String(JSON.stringify(arg));
+      var newArgs = ', ' + String(JSON.stringify(arg))
+      tokenArguments += newArgs;
+      convertArgs += newArgs;
     }
 
     var defaultValue = token.noDefault ? 
       '' : 
       ' || ' + JSON.stringify(token.defaultValue);
-    return '(convert["' + key + '"](' + tokenFunction + '(' + tokenArguments + '))' + defaultValue + ')';
+    return '(convert["' + key + '"](' + tokenFunction + '(' + tokenArguments + '), ' + convertArgs + ')' + defaultValue + ')';
   });
 
   return assignment;

--- a/test.js
+++ b/test.js
@@ -312,13 +312,16 @@ describe('morgan-json', function () {
         var compiled = json({
           number: {
             value: ':numString',
-            type: function (val) { 
+            type: function (val, name) {
+              assume(name).equals('numString');
               return parseInt(val, 10);
             } 
           },
           another: {
             value: ':req[accept-lang]',
-            type: function (val) { 
+            type: function (val, name, arg) {
+              assume(name).equals('req');
+              assume(arg).equals('accept-lang');
               return parseFloat(val);
             } 
           }
@@ -393,7 +396,9 @@ describe('morgan-json', function () {
         var compiled = json({
           empty: {
             value: ':req[none]',
-            type: function (val) { 
+            type: function (val, name, arg) {
+              assume(name).equals('req');
+              assume(arg).equals('none');
               return val && parseFloat(val);
             }
           }
@@ -409,7 +414,9 @@ describe('morgan-json', function () {
         var compiled = json({
           empty: {
             value: ':req[none]',
-            type: function (val) { 
+            type: function (val, name, arg) {
+              assume(name).equals('req');
+              assume(arg).equals('none');
               return val && parseFloat(val);
             },
             defaultValue: 987
@@ -456,7 +463,9 @@ describe('morgan-json', function () {
         var compiled = json({
           empty: {
             value: ':req[none]',
-            type: function (val) { 
+            type: function (val, name, arg) {
+              assume(name).equals('req');
+              assume(arg).equals('none');
               return val && parseFloat(val);
             },
             noDefault: true

--- a/test.js
+++ b/test.js
@@ -124,11 +124,10 @@ describe('morgan-json', function () {
   });
 
   describe('object tokens', function () {
-    const typedMock = {
+    var typedMock = {
       method: function () { return 'method' },
       url:    function () { return 'url' },
       status: function () { return 200 },
-      res:    function (req, res, arg) { return ['res', arg].join(' ') },
       req:    function (req, res, arg) { return ({
         'content-length': 123,
         'accept-lang': '5.67',
@@ -399,7 +398,8 @@ describe('morgan-json', function () {
             type: function (val, name, arg) {
               assume(name).equals('req');
               assume(arg).equals('none');
-              return val && parseFloat(val);
+              assume(val).is.null();
+              return null;
             }
           }
         });
@@ -417,7 +417,8 @@ describe('morgan-json', function () {
             type: function (val, name, arg) {
               assume(name).equals('req');
               assume(arg).equals('none');
-              return val && parseFloat(val);
+              assume(val).is.null();
+              return null;
             },
             defaultValue: 987
           }
@@ -466,7 +467,8 @@ describe('morgan-json', function () {
             type: function (val, name, arg) {
               assume(name).equals('req');
               assume(arg).equals('none');
-              return val && parseFloat(val);
+              assume(val).is.null();
+              return null;
             },
             noDefault: true
           }

--- a/test.js
+++ b/test.js
@@ -14,6 +14,7 @@ var mock = {
   status: function () { return 'status' },
   res:    function (req, res, arg) { return ['res', arg].join(' ') },
   'response-time': function () { return 'response-time' },
+  empty:  function () { return null },
 };
 
 //
@@ -22,83 +23,452 @@ var mock = {
 var invalidMsg = 'argument format must be a string or an object';
 
 describe('morgan-json', function () {
-  it('format string of all tokens', function () {
-    var compiled = json(':method :url :status :res[content-length] :response-time');
-    var output = compiled(mock);
+  describe('string tokens', function () {
+    it('format string of all tokens', function () {
+      var compiled = json(':method :url :status :res[content-length] :response-time');
+      var output = compiled(mock);
 
-    assume(output).deep.equals(JSON.stringify({
-      method: 'method',
-      url: 'url',
-      status: 'status',
-      res: 'res content-length',
-      'response-time': 'response-time'
-    }));
-  });
-
-  it('format string of all tokens (with trailers)', function () {
-    var compiled = json(':method :url :status :res[content-length] bytes :response-time ms');
-    var output = compiled(mock);
-
-    assume(output).deep.equals(JSON.stringify({
-      method: 'method',
-      url: 'url',
-      status: 'status',
-      res: 'res content-length bytes',
-      'response-time': 'response-time ms'
-    }));
-  });
-
-  it('format object of all single tokens (no trailers)', function () {
-    var compiled = json({
-      method: ':method',
-      url: ':url',
-      status: ':status',
-      'response-time': ':response-time',
-      length: ':res[content-length]'
+      assume(output).deep.equals(JSON.stringify({
+        method: 'method',
+        url: 'url',
+        status: 'status',
+        res: 'res content-length',
+        'response-time': 'response-time'
+      }));
     });
 
-    var output = compiled(mock);
-    assume(output).deep.equals(JSON.stringify({
-      method: 'method',
-      url: 'url',
-      status: 'status',
-      'response-time': 'response-time',
-      length: 'res content-length'
-    }))
-  });
+    it('format string of all tokens (with trailers)', function () {
+      var compiled = json(':method :url :status :res[content-length] bytes :response-time ms');
+      var output = compiled(mock);
 
-  it('format object with multiple tokens', function () {
-    var compiled = json({
-      short: ':method :url :status',
-      'response-time': ':response-time',
-      length: ':res[content-length]'
+      assume(output).deep.equals(JSON.stringify({
+        method: 'method',
+        url: 'url',
+        status: 'status',
+        res: 'res content-length bytes',
+        'response-time': 'response-time ms'
+      }));
     });
 
-    var output = compiled(mock);
-    assume(output).deep.equals(JSON.stringify({
-      short: 'method url status',
-      'response-time': 'response-time',
-      length: 'res content-length'
-    }));
-  });
+    it('format object of all single tokens (no trailers)', function () {
+      var compiled = json({
+        method: ':method',
+        url: ':url',
+        status: ':status',
+        'response-time': ':response-time',
+        length: ':res[content-length]'
+      });
 
-  it('format object of all tokens (with trailers)', function () {
-    var compiled = json({
-      method: 'GET :method',
-      url: '-> /:url',
-      status: 'Code :status',
-      'response-time': ':response-time ms',
-      length: ':res[content-length]'
+      var output = compiled(mock);
+      assume(output).deep.equals(JSON.stringify({
+        method: 'method',
+        url: 'url',
+        status: 'status',
+        'response-time': 'response-time',
+        length: 'res content-length'
+      }))
     });
 
-    var output = compiled(mock);
-    assume(output).deep.equals(JSON.stringify({
-      method: 'GET method',
-      url: '-> /url',
-      status: 'Code status',
-      'response-time': 'response-time ms',
-      length: 'res content-length'
-    }));
+    it('format object with multiple tokens', function () {
+      var compiled = json({
+        short: ':method :url :status',
+        'response-time': ':response-time',
+        length: ':res[content-length]'
+      });
+
+      var output = compiled(mock);
+      assume(output).deep.equals(JSON.stringify({
+        short: 'method url status',
+        'response-time': 'response-time',
+        length: 'res content-length'
+      }));
+    });
+
+    it('format object of all tokens (with trailers)', function () {
+      var compiled = json({
+        method: 'GET :method',
+        url: '-> /:url',
+        status: 'Code :status',
+        'response-time': ':response-time ms',
+        length: ':res[content-length]'
+      });
+
+      var output = compiled(mock);
+      assume(output).deep.equals(JSON.stringify({
+        method: 'GET method',
+        url: '-> /url',
+        status: 'Code status',
+        'response-time': 'response-time ms',
+        length: 'res content-length'
+      }));
+    });
+
+    it('defaults to "-"', function () {
+      var compiled = json({
+        simple: ':empty',
+        withTrailer: ':empty thing',
+        withPrefix: 'some :empty',
+        withBoth: 'some :empty thing',
+        withMultipleValues: ':method :empty :status'
+      });
+
+      var output = compiled(mock);
+      assume(output).deep.equals(JSON.stringify({
+        simple: '-',
+        withTrailer: '- thing',
+        withPrefix: 'some -',
+        withBoth: 'some - thing',
+        withMultipleValues: 'method - status'
+      }));
+    })
+  });
+
+  describe('object tokens', function () {
+    const typedMock = {
+      method: function () { return 'method' },
+      url:    function () { return 'url' },
+      status: function () { return 200 },
+      res:    function (req, res, arg) { return ['res', arg].join(' ') },
+      req:    function (req, res, arg) { return ({
+        'content-length': 123,
+        'accept-lang': '5.67',
+        none: null
+      })[arg] },
+      'response-time': function () { return 9.001 },
+      numString: function () { return "404" },
+      empty:  function () { return null },
+    };
+
+    describe('type support', function () {
+      it('accepts object tokens', function () {
+        var compiled = json({
+          method: {
+            value: ':method'
+          },
+          url: {
+            value: ':url'
+          },
+          status: {
+            value: ':status'
+          },
+          'response-time': {
+            value: ':response-time'
+          },
+          'request-size': {
+            value: ':req[content-length]'
+          }
+        });
+        
+        var output = compiled(typedMock);
+        assume(output).deep.equals(JSON.stringify({
+          method: 'method',
+          url: 'url',
+          status: '200',
+          'response-time': '9.001',
+          'request-size': '123'
+        }));
+      });
+
+      it('can mix string and object tokens', function () {
+        var compiled = json({
+          method: ':method',
+          url: {
+            value: ':url'
+          },
+          status: ':status',
+          'response-time': ':response-time',
+          'request-size': ':req[content-length]'
+        });
+        
+        var output = compiled(typedMock);
+        assume(output).deep.equals(JSON.stringify({
+          method: 'method',
+          url: 'url',
+          status: '200',
+          'response-time': '9.001',
+          'request-size': '123'
+        }));
+      });
+
+      it('allows type="*"', function () {
+        var compiled = json({
+          method: {
+            value: ':method',
+            type: '*'
+          },
+          url: {
+            value: ':url',
+            type: '*'
+          },
+          status: {
+            value: ':status',
+            type: '*'
+          },
+          'response-time': {
+            value: ':response-time',
+            type: '*'
+          },
+          'request-size': {
+            value: ':req[content-length]',
+            type: '*'
+          }
+        });
+
+        var output = compiled(typedMock);
+        assume(output).deep.equals(JSON.stringify({
+          method: 'method',
+          url: 'url',
+          status: 200,
+          'response-time': 9.001,
+          'request-size': 123
+        }));
+      });
+
+      it('allows type="string"', function () {
+        var compiled = json({
+          method: {
+            value: ':method',
+            type: 'string'
+          },
+          url: {
+            value: ':url',
+            type: 'string'
+          },
+          status: {
+            value: ':status',
+            type: 'string'
+          },
+          'response-time': {
+            value: ':response-time',
+            type: 'string'
+          },
+          'request-size': {
+            value: ':req[content-length]',
+            type: 'string'
+          }
+        });
+
+        var output = compiled(typedMock);
+        assume(output).deep.equals(JSON.stringify({
+          method: 'method',
+          url: 'url',
+          status: '200',
+          'response-time': '9.001',
+          'request-size': '123'
+        }));
+      });
+
+      it('allows mixed types', function () {
+        var compiled = json({
+          status: {
+            value: ':status',
+            type: 'string'
+          },
+          'response-time': {
+            value: ':response-time',
+            type: '*'
+          }
+        });
+
+        var output = compiled(typedMock);
+        assume(output).deep.equals(JSON.stringify({
+          status: '200',
+          'response-time': 9.001
+        }));
+      });
+
+      it('throws on invalid types', function () {
+        var error;
+        try {
+          json({
+            method: {
+              value: ':method',
+              type: 'not-supported'
+            }
+          });
+        } catch(err) {
+          error = err;
+        }
+
+        assume(error).to.exist();
+        assume(error.message).equals('invalid "type" specified for property: method')
+      });
+
+      it('can do math when type="*"', function () {
+        var compiled = json({
+          maths: {
+            value: ':status + :response-time',
+            type: '*'
+          }
+        });
+
+        var output = compiled(typedMock);
+        assume(output).deep.equals(JSON.stringify({
+          maths: 200 + 9.001
+        }));
+      });
+
+      it('can support type conversion', function () {
+        var compiled = json({
+          number: {
+            value: ':numString',
+            type: function (val) { 
+              return parseInt(val, 10);
+            } 
+          },
+          another: {
+            value: ':req[accept-lang]',
+            type: function (val) { 
+              return parseFloat(val);
+            } 
+          }
+        });
+
+        var output = compiled(typedMock);
+        assume(output).deep.equals(JSON.stringify({
+          number: 404,
+          another: 5.67
+        }));
+      });
+    });
+
+    describe('default values', function () {
+      it('defaults to "-" when no default provided', function () {
+        var compiled = json({
+          empty: {
+            value: ':empty'
+          }
+        });
+
+        var output = compiled(typedMock);
+        assume(output).deep.equals(JSON.stringify({
+          empty: '-'
+        }));
+      });
+
+      it('can provide other defaults', function () {
+        var compiled = json({
+          empty: {
+            value: ':empty',
+            defaultValue: 'N/A'
+          }
+        });
+
+        var output = compiled(typedMock);
+        assume(output).deep.equals(JSON.stringify({
+          empty: 'N/A'
+        }));
+      });
+
+      it('defaults when type="*"', function () {
+        var compiled = json({
+          empty: {
+            value: ':empty',
+            type: '*'
+          }
+        });
+
+        var output = compiled(typedMock);
+        assume(output).deep.equals(JSON.stringify({
+          empty: '-'
+        }));
+      });
+
+      it('can provide other defaults when type="*"', function () {
+        var compiled = json({
+          empty: {
+            value: ':empty',
+            type: '*',
+            defaultValue: 0
+          }
+        });
+
+        var output = compiled(typedMock);
+        assume(output).deep.equals(JSON.stringify({
+          empty: 0
+        }));
+      });
+
+      it('can defaults when type conversion', function () {
+        var compiled = json({
+          empty: {
+            value: ':req[none]',
+            type: function (val) { 
+              return val && parseFloat(val);
+            }
+          }
+        });
+
+        var output = compiled(typedMock);
+        assume(output).deep.equals(JSON.stringify({
+          empty: '-'
+        }));
+      });
+
+      it('can provide other defaults when type conversion', function () {
+        var compiled = json({
+          empty: {
+            value: ':req[none]',
+            type: function (val) { 
+              return val && parseFloat(val);
+            },
+            defaultValue: 987
+          }
+        });
+
+        var output = compiled(typedMock);
+        assume(output).deep.equals(JSON.stringify({
+          empty: 987
+        }));
+      });
+
+      it('can specify noDefault type="string" to get empty string', function () {
+        var compiled = json({
+          empty: {
+            value: ':empty',
+            type: 'string',
+            noDefault: true
+          }
+        });
+
+        var output = compiled(typedMock);
+        assume(output).deep.equals(JSON.stringify({
+          empty: ''
+        }));
+      });
+
+      it('can specify no default when type="*"', function () {
+        var compiled = json({
+          empty: {
+            value: ':empty',
+            type: '*',
+            noDefault: true
+          }
+        });
+
+        var output = compiled(typedMock);
+        assume(output).deep.equals(JSON.stringify({
+          empty: null
+        }));
+      });
+
+      it('can specify no default when type conversion', function () {
+        var compiled = json({
+          empty: {
+            value: ':req[none]',
+            type: function (val) { 
+              return val && parseFloat(val);
+            },
+            noDefault: true
+          }
+        });
+
+        var output = compiled(typedMock);
+        assume(output).deep.equals(JSON.stringify({
+          empty: null
+        }));
+      });
+    });
   });
 
   describe('{ stringify: false }', function () {


### PR DESCRIPTION
I hit an issue where I was trying to log request data via `debra` + `morgan-json` + `winston` into ElasticSearch. ElasticSearch is unfortunately pretty strict about its types for fields it receives. You can manually specify a type, but if a log entry/document specifies that field and it convertible to the specified type, the whole entry gets dropped. The issue come when I want to treat things like request content-length as numbers in elastic. Because not all entries from `debra` may have these fields (e.g. HTTP GET typically wouldn't have content-length specified), `morgan-json` was defaulting the field to be `"-"`.  That means that these log entries would be dropped in elastic search (or I have to specify the field as a string and lose the ability to easily aggregate values). To work around this I've made options objects available when using the object version of the compile method.

I'm leaving this as a draft PR until I've:
 - [x] Cleaned up the duplication introduced in `index.js`

I also realize that I've introduced a bit of vagueness in how types get handled when there are multiple tokens in the same property e.g. `json({ short: { value: ':method :status', type: ??? }}`. I'm not super happy with that, but couldn't see a reasonable way around it.

This PR provides a mechanism that addresses Issue #4 