### PR TITLE
[dist] Update dependencies to latest, use nyc instead of istanbul

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/indexzero/morgan-json#readme",
   "devDependencies": {
     "assume": "^2.2.0",
-    "mocha": "^8.1.3",
+    "mocha": "^9.2.2",
     "morgan": "^1.7.0",
     "nyc": "^15.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A variant of `morgan.compile` that provides format functions that output JSON",
   "main": "index.js",
   "scripts": {
-    "test": "istanbul cover _mocha test.js"
+    "test": "nyc --reporter=text --reporter=json-summary mocha test.js"
   },
   "repository": {
     "type": "git",
@@ -22,12 +22,12 @@
   },
   "homepage": "https://github.com/indexzero/morgan-json#readme",
   "devDependencies": {
-    "assume": "^1.4.1",
-    "istanbul": "^0.4.5",
-    "mocha": "^3.1.2",
-    "morgan": "^1.7.0"
+    "assume": "^2.2.0",
+    "mocha": "^8.1.3",
+    "morgan": "^1.7.0",
+    "nyc": "^15.1.0"
   },
   "dependencies": {
-    "diagnostics": "^1.0.1"
+    "diagnostics": "^2.0.2"
   }
 }


### PR DESCRIPTION
Pulled everything used here up to latest and swapped `istanbul` out for `nyc`

It could probably use to have `eslint` scripts added as well if there's a particular configuration setting you'd like to use, I could add that. It seems like it was run with eslint at some point given the existence of the [two](https://github.com/indexzero/morgan-json/blob/3a76010215a4256d41687d082cd66c4f00ea5717/index.js#L45) [lines](https://github.com/indexzero/morgan-json/blob/3a76010215a4256d41687d082cd66c4f00ea5717/index.js#L87) to disable a rule