### PR TITLE
fix(CVE-2022-25921): prevent arbitrary code execution

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,10 @@ module.exports = function compile (format, opts) {
 
   opts = opts || {};
 
-  var fmt = format.replace(/"/g, '\\"');
+  var fmt = format
+    .replace(/"/g, '\\"')
+    // remove everything until the first valid token
+    .replace(/^.*?(?=:)|.*/, '');
   var stringify = opts.stringify !== false ? 'JSON.stringify' : '';
   var js = '  "use strict"\n  return ' + stringify + '({' + fmt.replace(/:([-\w]{2,})(?:\[([^\]]+)\])?([^:]+)?/g, function (_, name, arg, trail, offset, str) {
     var tokenName = String(JSON.stringify(name));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morgan-json",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A variant of `morgan.compile` that provides format functions that output JSON",
   "main": "index.js",
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -152,4 +152,12 @@ describe('morgan-json', function () {
       assume(function () { json(''); }).throws('argument format string must not be empty');
     });
   });
+
+  describe('Malformed input', function () {
+    it('prevent arbitrary code execution (CVE-2022-25921)', function () {
+      var malformedInput = '}) + global.maliciousFunction() + ({'
+  
+      assume(function () { json(malformedInput)(''); }).not.throws('global.maliciousFunction is not a function');
+    });
+  });
 });


### PR DESCRIPTION
**Description:**

- fixes critical severity vulnerability reported by GitHub Advisory https://github.com/advisories/GHSA-fwv4-6mxc-x5h3
> All versions of package morgan-json are vulnerable to Arbitrary Code Execution due to missing sanitization of input passed to the Function constructor.
- a bit naive, but backward-compatible fix
- a security expert review is welcome
- unit test checks if the input was able to call a global function on behalf of the library - it would be better to have a stub for such check but I didn't want to introduce Sion or any other helper library
- @indexzero please dismiss this PR if you foresee a better solution, I've tried not to introduce breaking changes

